### PR TITLE
Fix undefined name 'ConfigurationError' in Interaction.py

### DIFF
--- a/block_zoo/attentions/Interaction.py
+++ b/block_zoo/attentions/Interaction.py
@@ -10,6 +10,7 @@ import copy
 from block_zoo.BaseLayer import BaseLayer, BaseConf
 from utils.DocInherit import DocInherit
 from utils.common_utils import transfer_to_gpu
+from utils.exceptions import ConfigurationError
 
 
 class InteractionConf(BaseConf):


### PR DESCRIPTION
__ConfigurationError__ is used on line 41 but it is never defined or imported.

[flake8](http://flake8.pycqa.org) testing of https://github.com/microsoft/NeuronBlocks on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./block_zoo/attentions/Interaction.py:40:19: F821 undefined name 'ConfigurationError'
            raise ConfigurationError("For Interaction layer, the sequence length should be fixed")
                  ^
1     F821 undefined name 'ConfigurationError'
1
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree
